### PR TITLE
SDL_MouseWheelEvent: Document preciseX and preciseY

### DIFF
--- a/SDL_MouseWheelEvent.mediawiki
+++ b/SDL_MouseWheelEvent.mediawiki
@@ -32,6 +32,14 @@ A structure that contains mouse wheel event information.
 |Uint32
 |'''direction'''
 |SDL_MOUSEWHEEL_NORMAL or SDL_MOUSEWHEEL_FLIPPED; see [[#Remarks|Remarks]] for details (>= SDL 2.0.4)
+|-
+|float
+|'''preciseX'''
+|the amount scrolled horizontally, positive to the right and negative to the left, with float precision (added in 2.0.18)
+|-
+|float
+|'''preciseY'''
+|the amount scrolled vertically, positive away from the user and negative toward the user, with float precision (added in 2.0.18)
 |}
 
 == Code Examples ==


### PR DESCRIPTION
The header documents these fields, but the wiki does not. This change simply copies the definitions from the header into the wiki.
https://github.com/libsdl-org/SDL/blob/120c76c84bbce4c1bfed4e9eb74e10678bd83120/include/SDL_events.h#L304

